### PR TITLE
TEC-7753 Sparse matrix improvements and allow floats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val commonSettings = Seq(
   organization := "com.github.haifengl",
   organizationName := "Haifeng Li",
   organizationHomepage := Some(url("http://haifengl.github.io/")),
-  version := "1.5.3",
+  version := "1.5.3-EBX-0",
   javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8", "-encoding", "UTF8", "-g:lines,vars,source", "-Xlint:unchecked"),
   javacOptions in (Compile, doc) ++= Seq("-Xdoclint:none"),
   javaOptions in test += "-Dsmile.threads=1",

--- a/core/src/main/java/smile/clustering/linkage/Linkage.java
+++ b/core/src/main/java/smile/clustering/linkage/Linkage.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2010 Haifeng Li
- *   
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -18,19 +18,25 @@ package smile.clustering.linkage;
 
 /**
  * A measure of dissimilarity between clusters (i.e. sets of observations).
- * 
+ *
  * <h2>References</h2>
  * <ol>
- * <li> Anil K. Jain, Richard C. Dubes. Algorithms for clustering data. 1988.</li> 
+ * <li> Anil K. Jain, Richard C. Dubes. Algorithms for clustering data. 1988.</li>
  * </ol>
- * 
+ *
  * @see smile.clustering.HierarchicalClustering
  *
  * @author Haifeng Li
+ *
+ * [EBX] Modifications made to file:
+ *  - init() now takes a float[] as an input instead of a double[][]. The proximity variable is
+ *  directly assigned since we provide directly a 1D condensed matrix. The 1D condensed matrix
+ *  was built from the 2D dense matrix in the original version
+ *
  */
 public abstract class Linkage {
     /** The data size. */
-    int size;
+    long size;
 
     /**
      * Linearized proximity matrix to store the pair-wise distance measure
@@ -43,37 +49,32 @@ public abstract class Linkage {
     float[] proximity;
 
     /** Initialize the linkage with the lower triangular proximity matrix. */
-    void init(double[][] proximity) {
-        size = proximity.length;
-        this.proximity = new float[size * (size+1) / 2];
-
-        // row wise
-        /*
-        for (int i = 0, k = 0; i < size; i++) {
-            double[] pi = proximity[i];
-            for (int j = 0; j <= i; j++, k++) {
-                this.proximity[k] = (float) pi[j];
-            }
-        }
-        */
-
-        // column wise
-        for (int j = 0, k = 0; j < size; j++) {
-            for (int i = j; i < size; i++, k++) {
-                this.proximity[k] = (float) proximity[i][j];
-            }
-        }
+    void init(float[] proximity) {
+        size = getSize(proximity);
+        this.proximity = proximity;
     }
 
-    int index(int i, int j) {
+    private int getSize(float[] proximity) {
+        int i = 0;
+        int sizeCondensed = proximity.length;
+        int result = 0;
+        while (result != sizeCondensed) {
+            i++;
+            result += i;
+        }
+        return i;
+    }
+
+    int index(long i, long j) {
         // row wise
         // return i > j ? i*(i+1)/2 + j : j*(j+1)/2 + i;
         // column wise
-        return i > j ? proximity.length - (size-j)*(size-j+1)/2 + i - j : proximity.length - (size-i)*(size-i+1)/2 + j - i;
+        return i > j ? (int) (proximity.length - (size-j)*(size-j+1)/2 + i - j) :
+            (int) (proximity.length - (size-i)*(size-i+1)/2 + j - i);
     }
 
     /** Returns the proximity matrix size. */
-    public int size() {
+    public long size() {
         return size;
     }
 

--- a/core/src/main/java/smile/clustering/linkage/Linkage.java
+++ b/core/src/main/java/smile/clustering/linkage/Linkage.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2010 Haifeng Li
- *
+ *   
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ *  
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -18,21 +18,15 @@ package smile.clustering.linkage;
 
 /**
  * A measure of dissimilarity between clusters (i.e. sets of observations).
- *
+ * 
  * <h2>References</h2>
  * <ol>
- * <li> Anil K. Jain, Richard C. Dubes. Algorithms for clustering data. 1988.</li>
+ * <li> Anil K. Jain, Richard C. Dubes. Algorithms for clustering data. 1988.</li> 
  * </ol>
- *
+ * 
  * @see smile.clustering.HierarchicalClustering
  *
  * @author Haifeng Li
- *
- * [EBX] Modifications made to file:
- *  - init() now takes a float[] as an input instead of a double[][]. The proximity variable is
- *  directly assigned since we provide directly a 1D condensed matrix. The 1D condensed matrix
- *  was built from the 2D dense matrix in the original version
- *
  */
 public abstract class Linkage {
     /** The data size. */
@@ -49,14 +43,35 @@ public abstract class Linkage {
     float[] proximity;
 
     /** Initialize the linkage with the lower triangular proximity matrix. */
+    void init(double[][] proximity) {
+        size = proximity.length;
+        this.proximity = new float[proximity.length * (proximity.length+1) / 2];
+
+        // row wise
+        /*
+        for (int i = 0, k = 0; i < size; i++) {
+            double[] pi = proximity[i];
+            for (int j = 0; j <= i; j++, k++) {
+                this.proximity[k] = (float) pi[j];
+            }
+        }
+        */
+
+        // column wise
+        for (int j = 0, k = 0; j < size; j++) {
+            for (int i = j; i < size; i++, k++) {
+                this.proximity[k] = (float) proximity[i][j];
+            }
+        }
+    }
+
     void init(float[] proximity) {
-        size = getSize(proximity);
+        size = getSize(proximity.length);
         this.proximity = proximity;
     }
 
-    private int getSize(float[] proximity) {
+    private int getSize(int sizeCondensed) {
         int i = 0;
-        int sizeCondensed = proximity.length;
         int result = 0;
         while (result != sizeCondensed) {
             i++;
@@ -65,17 +80,16 @@ public abstract class Linkage {
         return i;
     }
 
-    int index(long i, long j) {
+    int index(int i, int j) {
         // row wise
         // return i > j ? i*(i+1)/2 + j : j*(j+1)/2 + i;
         // column wise
-        return i > j ? (int) (proximity.length - (size-j)*(size-j+1)/2 + i - j) :
-            (int) (proximity.length - (size-i)*(size-i+1)/2 + j - i);
+        return (int) (i > j ? proximity.length - (size-j)*(size-j+1)/2 + i - j : proximity.length - (size-i)*(size-i+1)/2 + j - i);
     }
 
     /** Returns the proximity matrix size. */
-    public long size() {
-        return size;
+    public int size() {
+        return (int) size;
     }
 
     /**

--- a/core/src/main/java/smile/clustering/linkage/UPGMALinkage.java
+++ b/core/src/main/java/smile/clustering/linkage/UPGMALinkage.java
@@ -47,6 +47,18 @@ public class UPGMALinkage extends Linkage {
             n[i] = 1;
     }
 
+    /**
+     * Constructor float.
+     * @param proximity  the proximity matrix to store the distance measure of
+     * dissimilarity. To save space, we only need the lower half of matrix.
+     */
+    public UPGMALinkage(float[] proximity) {
+        init(proximity);
+        n = new int[proximity.length];
+        for (int i = 0; i < n.length; i++)
+            n[i] = 1;
+    }
+
     @Override
     public String toString() {
         return "UPGMA linkage";

--- a/data/src/main/java/smile/data/SparseDataset.java
+++ b/data/src/main/java/smile/data/SparseDataset.java
@@ -380,28 +380,33 @@ public class SparseDataset implements Iterable<Datum<SparseArray>> {
      * Convert into Harwell-Boeing column-compressed sparse matrix format.
      */
     public SparseMatrix toSparseMatrix() {
-        int[] pos = new int[numColumns];
-        int[] colIndex = new int[numColumns + 1];
-        for (int i = 0; i < numColumns; i++) {
-            colIndex[i + 1] = colIndex[i] + colSize[i];
-        }
-
+        return toSparseMatrix(true);
+    }
+    
+    /**
+     * Convert into Harwell-Boeing column-compressed sparse matrix format.
+     */
+    public SparseMatrix toSparseMatrix(boolean doubles) {
         int nrows = size();
-        int[] rowIndex = new int[n];
-        double[] x = new double[n];
+        SparseMatrix sparseMatrix = new SparseMatrix(nrows, numColumns, n, doubles);
+        
+        int[] pos = new int[numColumns];
+        for (int i = 0; i < numColumns; i++) {
+            sparseMatrix.colIndex[i + 1] = sparseMatrix.colIndex[i] + colSize[i];
+        }
 
         for (int i = 0; i < nrows; i++) {
             for (SparseArray.Entry e : get(i).x) {
                 int j = e.i;
-                int k = colIndex[j] + pos[j];
+                int k = sparseMatrix.colIndex[j] + pos[j];
 
-                rowIndex[k] = i;
-                x[k] = e.x;
+                sparseMatrix.rowIndex[k] = i;
+                sparseMatrix.set(k, e.x);
                 pos[j]++;
             }
         }
 
-        return new SparseMatrix(nrows, numColumns, x, rowIndex, colIndex);
+        return sparseMatrix;
     }
     
     /**

--- a/math/src/main/java/smile/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/smile/math/matrix/SparseMatrix.java
@@ -253,7 +253,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
 
         for (int j = 0; j < ncols; j++) {
             for (int i = colIndex[j]; i < colIndex[j + 1]; i++) {
-                y[rowIndex[i]] += get(i) * get(j);
+                y[rowIndex[i]] += get(i) * x[j];
             }
         }
 
@@ -264,7 +264,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
     public double[] axpy(double[] x, double[] y) {
         for (int j = 0; j < ncols; j++) {
             for (int i = colIndex[j]; i < colIndex[j + 1]; i++) {
-                y[rowIndex[i]] += get(i) * get(j);
+                y[rowIndex[i]] += get(i) * x[j];
             }
         }
 
@@ -279,7 +279,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
 
         for (int j = 0; j < ncols; j++) {
             for (int i = colIndex[j]; i < colIndex[j + 1]; i++) {
-                y[rowIndex[i]] += get(i) * get(j);
+                y[rowIndex[i]] += get(i) * x[j];
             }
         }
 
@@ -291,7 +291,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
         Arrays.fill(y, 0.0);
         for (int i = 0; i < ncols; i++) {
             for (int j = colIndex[i]; j < colIndex[i + 1]; j++) {
-                y[i] += get(j) * get(rowIndex[j]);
+                y[i] += get(j) * x[rowIndex[j]];
             }
         }
 
@@ -303,7 +303,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
     public double[] atxpy(double[] x, double[] y) {
         for (int i = 0; i < ncols; i++) {
             for (int j = colIndex[i]; j < colIndex[i + 1]; j++) {
-                y[i] += get(j) * get(rowIndex[j]);
+                y[i] += get(j) * x[rowIndex[j]];
             }
         }
 
@@ -315,7 +315,7 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
         for (int i = 0; i < ncols; i++) {
             y[i] *= b;
             for (int j = colIndex[i]; j < colIndex[i + 1]; j++) {
-                y[i] += get(j) * get(rowIndex[j]);
+                y[i] += get(j) * x[rowIndex[j]];
             }
         }
 

--- a/math/src/main/java/smile/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/smile/math/matrix/SparseMatrix.java
@@ -45,23 +45,23 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
     /**
      * The number of rows.
      */
-    private int nrows;
+    public final int nrows;
     /**
      * The number of columns.
      */
-    private int ncols;
+    public final int ncols;
     /**
      * The index of the start of columns.
      */
-    private int[] colIndex;
+    public final int[] colIndex;
     /**
      * The row indices of nonzero values.
      */
-    private int[] rowIndex;
+    public final int[] rowIndex;
     /**
      * The array of nonzero values stored column by column.
      */
-    private double[] x;
+    public final float[] x;
     /**
      * True if the matrix is symmetric.
      */
@@ -76,9 +76,9 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
     private SparseMatrix(int nrows, int ncols, int nvals) {
         this.nrows = nrows;
         this.ncols = ncols;
-        rowIndex = new int[nvals];
-        colIndex = new int[ncols + 1];
-        x = new double[nvals];
+        this.rowIndex = new int[nvals];
+        this.colIndex = new int[ncols + 1];
+        x = new float[nvals];
     }
 
     /**
@@ -159,6 +159,22 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
     @Override
     public int ncols() {
         return ncols;
+    }
+
+    public double[][] toDense() {
+        double[][] dense = new double[this.nrows][this.ncols];
+
+        for (int iColptr = 0; iColptr < this.colIndex.length - 1; iColptr++) {
+            int firstEntrySubscript = this.colIndex[iColptr];
+            int lastSubscriptCol = this.colIndex[iColptr + 1] - 1;
+
+            for (int subscript = firstEntrySubscript; subscript <= lastSubscriptCol; subscript++) {
+                int row = this.rowIndex[subscript];
+                double value = this.x[subscript];
+                dense[row][iColptr] = value;
+            }
+        }
+        return dense;
     }
 
     /**
@@ -402,6 +418,98 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
         return aat(AT);
     }
 
+    public SparseMatrix aatLowerTriangular() {
+        SparseMatrix AT = transpose();
+        return lowerTriangularSparseAAT(AT);
+    }
+
+    public SparseMatrix lowerTriangularSparseAAT(SparseMatrix AT) {
+
+        int m = nrows;
+        int[] done = new int[m];
+        for (int i = 0; i < m; i++) {
+            done[i] = -1;
+        }
+
+        // First pass determines the number of nonzeros.
+        int nDiag = 0;
+        int nNonDiagLowerTri = 0;
+        // Outer loop over columns of A' in AA'
+        for (int j = 0; j < m; j++) {
+            for (int i = AT.colIndex[j]; i < AT.colIndex[j + 1]; i++) {
+                int k = AT.rowIndex[i];
+                for (int l = colIndex[k]; l < colIndex[k + 1]; l++) {
+                    int h = rowIndex[l];
+                    // Test if contribution already included.
+                    if (done[h] != j) {
+                        done[h] = j;
+                        if (j == h) {
+                            nDiag++;
+                        } else if (h > j) {
+                            nNonDiagLowerTri++;
+                        }
+                    }
+                }
+            }
+        }
+
+        SparseMatrix lowerTriangularSparseAAT = new SparseMatrix(m, m, nDiag + nNonDiagLowerTri);
+
+        int nvals = 0;
+        for (int i = 0; i < m; i++) {
+            done[i] = -1;
+        }
+
+        // Second pass determines columns of aat. Code is identical to first
+        // pass except colIndex and rowIndex get assigned at appropriate places.
+        for (int j = 0; j < m; j++) {
+            lowerTriangularSparseAAT.colIndex[j] = nvals;
+            for (int i = AT.colIndex[j]; i < AT.colIndex[j + 1]; i++) {
+                int k = AT.rowIndex[i];
+                for (int l = colIndex[k]; l < colIndex[k + 1]; l++) {
+                    int h = rowIndex[l];
+                    if (h >= j) {
+                        if (done[h] != j) {
+                            done[h] = j;
+                            lowerTriangularSparseAAT.rowIndex[nvals] = h;
+                            nvals++;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Set last value.
+        lowerTriangularSparseAAT.colIndex[m] = nvals;
+
+        // Sort columns.
+        for (int j = 0; j < m; j++) {
+            if (lowerTriangularSparseAAT.colIndex[j + 1] - lowerTriangularSparseAAT.colIndex[j] > 1) {
+                Arrays.sort(lowerTriangularSparseAAT.rowIndex, lowerTriangularSparseAAT.colIndex[j], lowerTriangularSparseAAT.colIndex[j + 1]);
+            }
+        }
+
+        float[] temp = new float[m];
+        for (int i = 0; i < m; i++) {
+            for (int j = AT.colIndex[i]; j < AT.colIndex[i + 1]; j++) {
+                int k = AT.rowIndex[j];
+                for (int l = colIndex[k]; l < colIndex[k + 1]; l++) {
+                    int h = rowIndex[l];
+                    if (h >= i) {
+                        temp[h] += AT.x[j] * x[l];
+                    }
+                }
+            }
+
+            for (int j = lowerTriangularSparseAAT.colIndex[i]; j < lowerTriangularSparseAAT.colIndex[i + 1]; j++) {
+                int k = lowerTriangularSparseAAT.rowIndex[j];
+                lowerTriangularSparseAAT.x[j] = temp[k];
+                temp[k] = 0;
+            }
+        }
+        return lowerTriangularSparseAAT;
+    }
+
     private SparseMatrix aat(SparseMatrix AT) {
         int m = nrows;
         int[] done = new int[m];
@@ -460,20 +568,23 @@ public class SparseMatrix implements Matrix, MatrixMultiplication<SparseMatrix, 
             }
         }
 
-        double[] temp = new double[m];
+        float[] temp = new float[m];
         for (int i = 0; i < m; i++) {
             for (int j = AT.colIndex[i]; j < AT.colIndex[i + 1]; j++) {
                 int k = AT.rowIndex[j];
                 for (int l = colIndex[k]; l < colIndex[k + 1]; l++) {
                     int h = rowIndex[l];
+                    double value = AT.x[j] * x[l];
+//          if (value > 0.01) {
                     temp[h] += AT.x[j] * x[l];
+//          }
                 }
             }
 
             for (int j = aat.colIndex[i]; j < aat.colIndex[i + 1]; j++) {
                 int k = aat.rowIndex[j];
                 aat.x[j] = temp[k];
-                temp[k] = 0.0;
+                temp[k] = 0;
             }
         }
 


### PR DESCRIPTION
## [TEC-7753](https://jira.echobox.com/browse/TEC-7753) 

### Spec 
N/A

### Priority
Major

### Description of Changes
Update the forked SMILE library so that we can use it with floats rather than doubles and add the `aatLowerTriangular` and `toDense` methods